### PR TITLE
chore(renovate): switch extends to StudistCorporation/renovate-config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
-    "github>studistcorporation/.github:default.json5",
+    "github>StudistCorporation/renovate-config:default.json5",
 
     // https://docs.renovatebot.com/presets-default/
     ":disableMajorUpdates",


### PR DESCRIPTION
## Summary

Switch the Renovate shared preset reference from the legacy
`StudistCorporation/.github:default.json5` to the dedicated
`StudistCorporation/renovate-config:default.json5`.

This is part of the org-wide migration that consolidates the Renovate
preset into a single source-of-truth repository.

## Notes

- No behavioral change expected — the new preset mirrors the previous one.
- Generated via the bulk migration script (`migrate-renovate.sh`).